### PR TITLE
WIP: Events, auto-configuration

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,9 +1,59 @@
+var url = require('url');
+var util = require('util');
 var rest = require('restler');
+var WebSocket = require('ws');
 
-function Remote(url, id) {
-  this.url = url;
-  this.id = id || '_id';
+var RPCService = require('./lib/service-rpc');
+
+function Remote(base, id) {
+  this.url = base;
+  this.id = id || 'id';
+
+  var parsed = url.parse(base);
+
+  this.host = parsed.host;
+  this.path = parsed.path;
+
+  this.resourceMap = {};
 }
+
+util.inherits(Remote, require('events').EventEmitter);
+
+Remote.prototype.init = function(cb) {
+  var self = this;
+  if (!cb) var cb = new Function();
+
+  self._options('/', function(err, options) {
+    self.resources = options.resources;
+
+    options.resources.forEach(function(r) {
+      self.resourceMap[r.name] = r;
+    });
+
+    var endpoint = 'ws://' + self.host + self.path;
+
+    self.ws = new WebSocket(endpoint);
+    self.ws.on('open', self.emit.bind(self, 'open'));
+    self.ws.on('message', function(msg) {
+      self.emit('message', JSON.parse(msg));
+    });
+
+    cb();
+  });
+};
+
+Remote.prototype._options = function(url, cb) {
+  var self = this;
+  rest.request( this.url + url , {
+    method: 'OPTIONS',
+    parser: rest.parsers.json,
+    headers: {
+      'Accept': 'application/json'
+    }
+  }).on('complete', function(data) {
+    return cb(null, data);
+  });
+};
 
 Remote.prototype._get = function(url, cb) {
   var self = this;
@@ -24,6 +74,26 @@ Remote.prototype._post = function(url, data, cb) {
     data = {};
   }
   rest.postJson( this.url + url , data, {
+    headers: {
+      'Accept': 'application/json'
+    }
+  }).on('complete', function(data) {
+    if (!data[ self.id ]) return cb(data);
+    return cb(null, data);
+  });
+};
+
+Remote.prototype._put = function(url, data, cb) {
+  var self = this;
+  if (typeof data === 'function') {
+    cb = data;
+    data = {};
+  }
+
+  var endpoint = this.url + url;
+  console.log('_put endpoint:', endpoint);
+
+  rest.putJson(endpoint, data, {
     headers: {
       'Accept': 'application/json'
     }

--- a/index.js
+++ b/index.js
@@ -116,7 +116,7 @@ Remote.prototype._get = function(url, params, cb) {
       'Accept': 'application/json'
     }
   }).on('complete', function(data) {
-    if (!data[ self.id ]) return cb(data);
+    if (!data[ self.id ]) return cb(null, data);
     return cb(null, data);
   });
 };

--- a/index.js
+++ b/index.js
@@ -103,8 +103,14 @@ Remote.prototype._options = function(url, cb) {
   });
 };
 
-Remote.prototype._get = function(url, cb) {
+Remote.prototype._get = function(url, params, cb) {
   var self = this;
+  
+  if (typeof params === 'function') {
+    cb = params;
+    params = {};
+  }
+  
   rest.get( this.url + url , {
     headers: {
       'Accept': 'application/json'

--- a/index.js
+++ b/index.js
@@ -116,7 +116,6 @@ Remote.prototype._get = function(url, params, cb) {
       'Accept': 'application/json'
     }
   }).on('complete', function(data) {
-    if (!data[ self.id ]) return cb(null, data);
     return cb(null, data);
   });
 };
@@ -132,7 +131,6 @@ Remote.prototype._post = function(url, data, cb) {
       'Accept': 'application/json'
     }
   }).on('complete', function(data) {
-    if (!data[ self.id ]) return cb(data);
     return cb(null, data);
   });
 };
@@ -152,7 +150,6 @@ Remote.prototype._put = function(url, data, cb) {
       'Accept': 'application/json'
     }
   }).on('complete', function(data) {
-    if (!data[ self.id ]) return cb(data);
     return cb(null, data);
   });
 };
@@ -169,7 +166,6 @@ Remote.prototype._patch = function(url, data, cb) {
     },
     data: data
   }).on('complete', function(data) {
-    if (!data[ self.id ]) return cb(data);
     return cb(null, data);
   });
 };

--- a/lib/service-rpc.js
+++ b/lib/service-rpc.js
@@ -1,0 +1,16 @@
+var uuid = require('node-uuid');
+var jsonRPC = function( method , params ) {
+  this._method = method;
+  this._params = params;
+}
+jsonRPC.prototype.toJSON = function(notify) {
+  var self = this;
+  return JSON.stringify({
+    'jsonrpc': '2.0',
+    'method': self._method,
+    'params': self._params,
+    'id': (notify === false) ? undefined : uuid.v1()
+  });
+}
+
+module.exports = jsonRPC;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maki-remote",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "bind to a remote service directly within a maki app",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maki-remote",
-  "version": "0.0.3",
+  "version": "0.1.0",
   "description": "bind to a remote service directly within a maki app",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maki-remote",
-  "version": "0.2.0",
+  "version": "0.3.0-pre",
   "description": "bind to a remote service directly within a maki app",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,10 @@
   },
   "homepage": "https://github.com/martindale/maki-remote",
   "dependencies": {
-    "restler": "^3.3.0"
+    "async": "^2.0.0-rc.6",
+    "node-uuid": "^1.4.7",
+    "restler": "^3.3.0",
+    "ws": "^1.1.1"
   },
   "devDependencies": {
     "coveralls": "^2.11.4",

--- a/test/Remote.integration.js
+++ b/test/Remote.integration.js
@@ -1,0 +1,41 @@
+describe('Remote', function() {
+  describe('init', function() {
+    it('should get OPTIONS', function(done) {
+      var Remote = require('../');
+      var remote = new Remote('http://localhost:9200');
+      remote.init(function() {
+        done();
+      });
+    });
+    it('should open a websocket', function(done) {
+      var Remote = require('../');
+      var remote = new Remote('http://localhost:9200');
+
+      remote.on('open', done);
+      remote.init();
+    });
+  });
+  describe('create', function() {
+    it('should receive updates', function(done) {
+      var Remote = require('../');
+      var remote = new Remote('http://localhost:9200');
+
+      remote.on('message', function(msg) {
+        if (msg.method === 'patch' && msg.params.channel === '/invitations') {
+          done();
+        }
+      });
+
+      remote.on('open', function() {
+        remote._post('/invitations', {
+          email: 'eric@ericmartindale.com'
+        }, function(data) {
+          console.log('_post:', data);
+        });
+      });
+
+      remote.init();
+
+    });
+  });
+});


### PR DESCRIPTION
This adds support for a long-lived `Remote`, which will:
- ask the Maki server for a list of Resources when instantiated (via `OPTIONS /`)
- subscribe to updates via Maki's events API

TODO:
- [ ] automatically reconnect on disconnect (with backoff)
- [ ] handle JSON-RPC more intelligently
